### PR TITLE
Provide better errors when conbench is unreachable

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: conbenchcoms
 Title: An API wrapper for conbench communications
-Version: 0.0.4
+Version: 0.0.5
 Authors@R: c(
     person("Jonathan", "Keane", , "jon@voltrondata.com", role = c("aut", "ctb"),
            comment = c(ORCID = "0000-0001-7087-9776")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+# conbenchcoms 0.0.5
+* display more verbose errors when the Conbench API returns an error
+
 # conbenchcoms 0.0.4
 * add threshold endpoints to conbenchcoms
 

--- a/R/session.R
+++ b/R/session.R
@@ -12,12 +12,12 @@
 #' @export
 conbench_perform <- function(data, ...) {
 
-  # browser()
   # if session is already here, then we can use that
   resp <- data |>
     req_error(is_error = function(resp) FALSE) |>
     req_headers(cookie = .conbench_session$cookie) |>
     req_perform(...)
+
 
   # TODO: is this status too narrow?
   if (resp_status(resp) == 401L) {
@@ -29,25 +29,12 @@ conbench_perform <- function(data, ...) {
       req_perform(...)
   }
 
+
   if (resp_is_error(resp)) {
     stop(error_body(resp), call. = FALSE)
   }
 
   resp
-}
-
-indent <- function(message) {
-  lines <- unlist(strsplit(message, "\n")) # Split the message into lines
-  indent <- paste(rep(" ", 2), collapse = "") # Create the indentation string
-  indented_lines <- paste(indent, lines, sep = "") # Add indentation
-  paste(indented_lines, collapse = "\n") # Combine the lines with newline characters
-}
-
-error_body <- function(resp) {
-  method <- indent(glue::glue("{resp['method']} {resp['url']}"))
-  status_code <- indent(glue::glue("Status code: {resp[['status_code']]}"))
-  indented_message <- indent(resp_body_string(resp))
-  glue::glue("\n\nRequest details:\n{method}\nResponse details:\n{status_code}\n---\n{indented_message}")
 }
 
 auth_conbench <- function() {
@@ -61,6 +48,13 @@ auth_conbench <- function() {
 
   resp <- req_perform(req)
   .conbench_session$cookie <- resp_header(resp, "set-cookie")
+}
+
+error_body <- function(resp) {
+  method <- indent(glue::glue("{resp['method']} {resp['url']}"))
+  status_code <- indent(glue::glue("Status code: {resp[['status_code']]}"))
+  indented_message <- indent(resp_body_string(resp))
+  glue::glue("\n\nRequest details:\n{method}\nResponse details:\n{status_code}\n---\n{indented_message}")
 }
 
 get_config <- function() {
@@ -83,6 +77,13 @@ get_config <- function() {
     )
   }
   creds
+}
+
+indent <- function(message) {
+  lines <- unlist(strsplit(message, "\n")) # Split the message into lines
+  indent <- paste(rep(" ", 2), collapse = "") # Create the indentation string
+  indented_lines <- paste(indent, lines, sep = "") # Add indentation
+  paste(indented_lines, collapse = "\n") # Combine the lines with newline characters
 }
 
 .conbench_session <- new.env(parent = emptyenv())

--- a/R/session.R
+++ b/R/session.R
@@ -11,19 +11,8 @@
 #' @return the response
 #' @export
 conbench_perform <- function(data, ...) {
-  error_body <- function(resp) {
 
-    method <- resp[['method']]
-    url <- resp[['url']]
-    status_code <- resp[['status_code']]
-    message(glue::glue("Request details: {method} {url}"))
-
-    message("Response details:")
-    message(glue::glue("Status code: {status_code}"))
-
-    message(resp_body_string(resp))
-  }
-
+  # browser()
   # if session is already here, then we can use that
   resp <- data |>
     req_error(is_error = function(resp) FALSE) |>
@@ -35,11 +24,30 @@ conbench_perform <- function(data, ...) {
     auth_conbench()
 
     resp <- data |>
+      req_error(is_error = function(resp) FALSE) |>
       req_headers(cookie = .conbench_session$cookie) |>
-      req_error(body = error_body) |>
       req_perform(...)
   }
+
+  if (resp_is_error(resp)) {
+    stop(error_body(resp), call. = FALSE)
+  }
+
   resp
+}
+
+indent <- function(message) {
+  lines <- unlist(strsplit(message, "\n")) # Split the message into lines
+  indent <- paste(rep(" ", 2), collapse = "") # Create the indentation string
+  indented_lines <- paste(indent, lines, sep = "") # Add indentation
+  paste(indented_lines, collapse = "\n") # Combine the lines with newline characters
+}
+
+error_body <- function(resp) {
+  method <- indent(glue::glue("{resp['method']} {resp['url']}"))
+  status_code <- indent(glue::glue("Status code: {resp[['status_code']]}"))
+  indented_message <- indent(resp_body_string(resp))
+  glue::glue("\n\nRequest details:\n{method}\nResponse details:\n{status_code}\n---\n{indented_message}")
 }
 
 auth_conbench <- function() {

--- a/R/session.R
+++ b/R/session.R
@@ -11,6 +11,19 @@
 #' @return the response
 #' @export
 conbench_perform <- function(data, ...) {
+  error_body <- function(resp) {
+
+    method <- resp[['method']]
+    url <- resp[['url']]
+    status_code <- resp[['status_code']]
+    message(glue::glue("Request details: {method} {url}"))
+
+    message("Response details:")
+    message(glue::glue("Status code: {status_code}"))
+
+    message(resp_body_string(resp))
+  }
+
   # if session is already here, then we can use that
   resp <- data |>
     req_error(is_error = function(resp) FALSE) |>
@@ -23,9 +36,9 @@ conbench_perform <- function(data, ...) {
 
     resp <- data |>
       req_headers(cookie = .conbench_session$cookie) |>
+      req_error(body = error_body) |>
       req_perform(...)
   }
-
   resp
 }
 

--- a/R/session.R
+++ b/R/session.R
@@ -11,13 +11,11 @@
 #' @return the response
 #' @export
 conbench_perform <- function(data, ...) {
-
   # if session is already here, then we can use that
   resp <- data |>
     req_error(is_error = function(resp) FALSE) |>
     req_headers(cookie = .conbench_session$cookie) |>
     req_perform(...)
-
 
   # TODO: is this status too narrow?
   if (resp_status(resp) == 401L) {

--- a/man/compare.Rd
+++ b/man/compare.Rd
@@ -20,9 +20,11 @@ compare(
 
 \item{contender}{the contender sha of the entity to compare}
 
-\item{zscore_threshold}{the zscore threshold to mark regressions and improvements}
+\item{zscore_threshold}{the zscore threshold to mark regressions and improvements.
+Default is defined at the Conbench api level.}
 
-\item{pairwise_percent_threshold}{the pairwise_percent_threshold to mark regressions and improvements}
+\item{pairwise_percent_threshold}{the pairwise_percent_threshold to mark regressions and improvements.
+Default is defined at the Conbench api level.}
 
 \item{...}{
   Arguments passed on to \code{\link[httr2:resp_body_raw]{httr2::resp_body_json}}

--- a/tests/testthat/test-session.R
+++ b/tests/testthat/test-session.R
@@ -21,7 +21,7 @@ test_that("get_config works to three env vars even when dot_conbench is present"
   expect_identical(set3envs$password, "starr")
 })
 
-test_that("get_config errors when it has no environment variables",{
+test_that("get_config errors when it has no environment variables", {
   expect_error(
     test_get_config_env_vars(
       list(
@@ -34,12 +34,13 @@ test_that("get_config errors when it has no environment variables",{
 with_mock_dir(test_path("not-logged-in"), {
   test_that("Can log in", {
     expect_null(.conbench_session$cookie)
-    resp <- request("http://localhost/api") |>
-      req_url_path_append("users") |>
-      conbench_perform()
-    # This is still a 401 becuase httptest2 only has one possible response for users
-    expect_identical(resp_status(resp), 401L)
+    expect_error(
+      resp <- request("http://localhost/api") |>
+        req_url_path_append("users") |>
+        conbench_perform()
+    )
     expect_identical(.conbench_session$cookie, "REDACTED")
+
   })
 })
 

--- a/tests/testthat/test-session.R
+++ b/tests/testthat/test-session.R
@@ -34,11 +34,11 @@ test_that("get_config errors when it has no environment variables", {
 with_mock_dir(test_path("not-logged-in"), {
   test_that("Can log in", {
     expect_null(.conbench_session$cookie)
-    expect_error(
-      resp <- request("http://localhost/api") |>
-        req_url_path_append("users") |>
-        conbench_perform()
-    )
+    resp <- request("http://localhost/api") |>
+      req_url_path_append("users") |>
+      conbench_perform()
+    # This is still a 401 becuase httptest2 only has one possible response for users
+    expect_identical(resp_status(resp), 401L)
     expect_identical(.conbench_session$cookie, "REDACTED")
 
   })


### PR DESCRIPTION
Closes #6 

This add some better error messages when a request errors with conbench. To simulate an error I temporarily removed the check for when `days` needs to be a parameter. So that call errors and then produces an error message that looks like:

```r
R> foo <- benchmark_results(run_reason = "foo", days = "foo")
Error in `req_perform()` at conbenchcoms/R/session.R:24:2:
! HTTP 500 Internal Server Error.
• Request details:
  GET https://conbench.ursa.dev:443/api/benchmark-results/?run_reason=foo&days=foo

Response details:
  Status code: 500
---

  unexpected exception, please report this:
  Traceback (most recent call last):
    File "/usr/local/lib/python3.11/site-packages/flask/app.py", line 1823, in full_dispatch_request
      rv = self.dispatch_request()
           ^^^^^^^^^^^^^^^^^^^^^^^
    File "/usr/local/lib/python3.11/site-packages/flask/app.py", line 1799, in dispatch_request
      return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/usr/local/lib/python3.11/site-packages/flask/views.py", line 107, in view
      return current_app.ensure_sync(self.dispatch_request)(**kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/usr/local/lib/python3.11/site-packages/flask/views.py", line 188, in dispatch_request
      return current_app.ensure_sync(meth)(**kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/app/conbench/api/_endpoint.py", line 23, in maybe
      return func(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^
    File "/app/conbench/api/results.py", line 191, in get
      ).date() - datetime.timedelta(days=int(days))
                                         ^^^^^^^^^
  ValueError: invalid literal for int() with base 10: 'foo'
 ```