### PR TITLE
Revert "Provide better errors when conbench is unreachable"

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: conbenchcoms
 Title: An API wrapper for conbench communications
-Version: 0.0.5
+Version: 0.0.4
 Authors@R: c(
     person("Jonathan", "Keane", , "jon@voltrondata.com", role = c("aut", "ctb"),
            comment = c(ORCID = "0000-0001-7087-9776")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,3 @@
-# conbenchcoms 0.0.5
-* display more verbose errors when the Conbench API returns an error
-
 # conbenchcoms 0.0.4
 * add threshold endpoints to conbenchcoms
 

--- a/man/compare.Rd
+++ b/man/compare.Rd
@@ -20,11 +20,9 @@ compare(
 
 \item{contender}{the contender sha of the entity to compare}
 
-\item{zscore_threshold}{the zscore threshold to mark regressions and improvements.
-Default is defined at the Conbench api level.}
+\item{zscore_threshold}{the zscore threshold to mark regressions and improvements}
 
-\item{pairwise_percent_threshold}{the pairwise_percent_threshold to mark regressions and improvements.
-Default is defined at the Conbench api level.}
+\item{pairwise_percent_threshold}{the pairwise_percent_threshold to mark regressions and improvements}
 
 \item{...}{
   Arguments passed on to \code{\link[httr2:resp_body_raw]{httr2::resp_body_json}}

--- a/tests/testthat/test-session.R
+++ b/tests/testthat/test-session.R
@@ -21,7 +21,7 @@ test_that("get_config works to three env vars even when dot_conbench is present"
   expect_identical(set3envs$password, "starr")
 })
 
-test_that("get_config errors when it has no environment variables", {
+test_that("get_config errors when it has no environment variables",{
   expect_error(
     test_get_config_env_vars(
       list(
@@ -40,7 +40,6 @@ with_mock_dir(test_path("not-logged-in"), {
     # This is still a 401 becuase httptest2 only has one possible response for users
     expect_identical(resp_status(resp), 401L)
     expect_identical(.conbench_session$cookie, "REDACTED")
-
   })
 })
 


### PR DESCRIPTION
Reverts conbench/conbenchcoms#13 for the moment as everything was being returned as an error which is obviously not what we want. 